### PR TITLE
DocGenerator may use parameter name instead of description

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ The docker is ran with the following command:
 docker run -it -v $srcDir:/src  <DOCKER_NAME>:<DOCKER_VERSION>
 ```
 
+#### Generate Docs
+
+1. Update the version in `src/main/resources/docs/patterns.json`
+
+2. Run the DocGenerator
+```sh
+sbt "run-main codacy.checkstyle.DocGenerator"
+```
+
 ## Docs
 
 [Tool Developer Guide](https://support.codacy.com/hc/en-us/articles/207994725-Tool-Developer-Guide)

--- a/src/main/scala/codacy/checkstyle/DocGenerator.scala
+++ b/src/main/scala/codacy/checkstyle/DocGenerator.scala
@@ -72,8 +72,15 @@ object DocGenerator extends JsonApi {
                   // Try to parse numbers and booleans
                   val jsDefaultValue = Try(Json.parse(defaultValue)).getOrElse(JsString(defaultValue))
 
+                  val descriptionText =
+                    if(description.text.length > 250) {
+                      name.text
+                    } else {
+                      description.text
+                    }
+
                   (Parameter.Specification(Parameter.Name(name.text), Parameter.Value(jsDefaultValue)),
-                    Parameter.Description(Parameter.Name(name.text), Parameter.DescriptionText(description.text)))
+                    Parameter.Description(Parameter.Name(name.text), Parameter.DescriptionText(descriptionText)))
               }
         }
 


### PR DESCRIPTION
DocGenerator uses parameter name instead of description when description is too long