### PR TITLE
feature: Add file level error granularity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@1.0.1
-  codacy_plugins_test: codacy/plugins-test@0.5.0
+  codacy: codacy/base@1.2.1
+  codacy_plugins_test: codacy/plugins-test@0.6.6
 
 workflows:
   version: 2

--- a/src/main/resources/docs/multiple-tests/with-config-file/results.xml
+++ b/src/main/resources/docs/multiple-tests/with-config-file/results.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <checkstyle version="4.3">
     <file name="LineLength.java">
+        <error source="JavadocPackage" line="1" message="Missing package-info.java file." severity="info" />
         <error source="DesignForExtension" line="18" message="Class &apos;Something&apos; looks like designed for extension (can be subclassed), but the method &apos;doSomething&apos; does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class &apos;Something&apos; final or making the method &apos;doSomething&apos; static/final/abstract/empty, or adding allowed annotation for the method." severity="info" />
         <error source="DesignForExtension" line="12" message="Class &apos;Something&apos; looks like designed for extension (can be subclassed), but the method &apos;doSomething&apos; does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class &apos;Something&apos; final or making the method &apos;doSomething&apos; static/final/abstract/empty, or adding allowed annotation for the method." severity="info" />
         <error source="MethodName" line="8" message="Name &apos;____bar&apos; must match pattern &apos;^[a-z][a-zA-Z0-9]*$&apos;." severity="info" />

--- a/src/main/scala/codacy/checkstyle/package.scala
+++ b/src/main/scala/codacy/checkstyle/package.scala
@@ -1,0 +1,10 @@
+package codacy
+
+import com.puppycrawl.tools.checkstyle.Checker
+import scala.util.Using.Releasable
+
+package object checkstyle {
+  implicit val checkerReleasable = new Releasable[Checker] {
+    def release(resource: Checker): Unit = resource.destroy()
+  }
+}


### PR DESCRIPTION
At the moment (current master), when Checkstyle throws an exception during the analysis process, we fail analysis as a whole, with a global error message.
This PR launches the tool file by file, catching the exceptions and returning them as file errors.