### PR TITLE
fix: Add config_loc property

### DIFF
--- a/src/main/resources/docs/multiple-tests/configloc/patterns.xml
+++ b/src/main/resources/docs/multiple-tests/configloc/patterns.xml
@@ -1,0 +1,5 @@
+<module name="root">
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="checkstyle\.xml,suppressions.xml" />
+    </module>
+</module>

--- a/src/main/resources/docs/multiple-tests/configloc/results.xml
+++ b/src/main/resources/docs/multiple-tests/configloc/results.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="4.3" />

--- a/src/main/resources/docs/multiple-tests/configloc/src/Constants.java
+++ b/src/main/resources/docs/multiple-tests/configloc/src/Constants.java
@@ -1,0 +1,3 @@
+public class Constants {
+
+}

--- a/src/main/resources/docs/multiple-tests/configloc/src/LineLength.java
+++ b/src/main/resources/docs/multiple-tests/configloc/src/LineLength.java
@@ -1,0 +1,5 @@
+public class LineLength {    
+    public static void doSomething() {
+        println("veeeeeeery loooooong string!!!!!");
+    }
+}

--- a/src/main/resources/docs/multiple-tests/configloc/src/checkstyle.xml
+++ b/src/main/resources/docs/multiple-tests/configloc/src/checkstyle.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <property name="charset" value="UTF-8" />
+
+    <property name="fileExtensions" value="java, properties, xml" />
+
+    <module name="SuppressionFilter">
+        <property name="file" value="${config_loc}/suppressions.xml" />
+    </module>
+
+    <module name="LineLength">
+        <property name="max" value="40" />
+        <property name="severity" value="ignore" />
+    </module>
+</module>

--- a/src/main/resources/docs/multiple-tests/configloc/src/suppressions.xml
+++ b/src/main/resources/docs/multiple-tests/configloc/src/suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.0//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+<suppressions>
+    <suppress checks="."
+              files="Constants.java" />
+</suppressions>

--- a/src/main/scala/codacy/checkstyle/Checkstyle.scala
+++ b/src/main/scala/codacy/checkstyle/Checkstyle.scala
@@ -44,8 +44,17 @@ object Checkstyle extends Tool {
     run(filesToLint, config)
   }
 
-  private def setCheckstyleConfigLocationProperty(configFilePath: String) = {
-    val parentPath = File(configFilePath).path.getParent.toAbsolutePath.toString
+  /**
+    * Checkstyle plugin defines a config_loc property that can be used in Checkstyle configuration
+    * files to define paths to other config files like suppressions.xml.
+    * We should define it for users to be able to use this property on the configuration file.
+    *
+    * @see <a href="https://docs.gradle.org/6.5.1/userguide/checkstyle_plugin.html#sec:checkstyle_built_in_variables">Checkstyle built in vars</a>
+    *
+    * @param configFilePath the path to checkstyle configuration file§
+    */
+  private def setCheckstyleConfigLocationProperty(configFilePath: String): Unit = {
+    val parentPath = File(configFilePath).parent.pathAsString
     System.setProperty("config_loc", parentPath)
   }
 

--- a/src/main/scala/codacy/checkstyle/Checkstyle.scala
+++ b/src/main/scala/codacy/checkstyle/Checkstyle.scala
@@ -33,6 +33,8 @@ object Checkstyle extends Tool {
         }
     }
 
+    setCheckstyleConfigLocationProperty(configFile)
+
     val config = ConfigurationLoader.loadConfiguration(
       configFile,
       new PropertiesExpander(System.getProperties),
@@ -40,6 +42,11 @@ object Checkstyle extends Tool {
       ThreadModeSettings.SINGLE_THREAD_MODE_INSTANCE
     )
     run(filesToLint, config)
+  }
+
+  private def setCheckstyleConfigLocationProperty(configFilePath: String) = {
+    val parentPath = File(configFilePath).path.getParent.toAbsolutePath.toString
+    System.setProperty("config_loc", parentPath)
   }
 
   private def run(files: Set[Source.File], config: Configuration): List[Result] = {


### PR DESCRIPTION
https://github.com/codacy/codacy-meta/issues/433

Checkstyle plugin defines a `config_loc` property that can be used in Checkstyle configuration files to define paths to other config files like `suppressions.xml`. We should define it for users to be able to use this property on the configuration file.

https://docs.gradle.org/current/userguide/checkstyle_plugin.html#sec:checkstyle_built_in_variables
