### PR TITLE
Fix/package name pattern CY-5185

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@
 .metals/
 project/.bloop/
 .bloop/
+.bsp/
 .vscode
 .version

--- a/docs/description/AnnotationLocation.md
+++ b/docs/description/AnnotationLocation.md
@@ -20,6 +20,9 @@ Checkstyle can not examine the target of an annotation.
 
 Example:
 
-    @Override
-    @Nullable
-    public String getNameIfPresent() { ... }
+``` 
+@Override
+@Nullable
+public String getNameIfPresent() { ... }
+        
+```

--- a/docs/description/AnnotationUseStyle.md
+++ b/docs/description/AnnotationUseStyle.md
@@ -2,9 +2,9 @@ Checks the style of elements in annotations.
 
 Annotations have three element styles starting with the least verbose.
 
--   `ElementStyleOption.COMPACT_NO_ARRAY`
--   `ElementStyleOption.COMPACT`
--   `ElementStyleOption.EXPANDED`
+  - `ElementStyleOption.COMPACT_NO_ARRAY`
+  - `ElementStyleOption.COMPACT`
+  - `ElementStyleOption.EXPANDED`
 
 To not enforce an element style a `ElementStyleOption.IGNORE` type is
 provided. The desired style can be set through the `elementStyle`

--- a/docs/description/ArrayTrailingComma.md
+++ b/docs/description/ArrayTrailingComma.md
@@ -1,59 +1,70 @@
 Checks that array initialization contains a trailing comma.
 
-    int[] a = new int[]
-    {
-      1,
-      2,
-      3,
-    };
-            
+``` 
+int[] a = new int[]
+{
+  1,
+  2,
+  3,
+};
+        
+```
 
 By default, the check demands a comma at the end if neither left nor
 right curly braces are on the same line as the last element of the
 array.
 
-    return new int[] { 0 };
-    return new int[] { 0
-      };
-    return new int[] {
-      0 };
-            
+``` 
+return new int[] { 0 };
+return new int[] { 0
+  };
+return new int[] {
+  0 };
+        
+```
 
 Rationale: Putting this comma in makes it easier to change the order of
 the elements or add new elements on the end. Main benefit of a trailing
 comma is that when you add new entry to an array, no surrounding lines
 are changed.
 
-    {
-      100000000000000000000,
-      200000000000000000000, // OK
-    }
+``` 
+{
+  100000000000000000000,
+  200000000000000000000, // OK
+}
 
-    {
-      100000000000000000000,
-      200000000000000000000,
-      300000000000000000000,  // Just this line added, no other changes
-    }
-            
+{
+  100000000000000000000,
+  200000000000000000000,
+  300000000000000000000,  // Just this line added, no other changes
+}
+        
+```
 
 If closing brace is on the same line as trailing comma, this benefit is
 gone (as the check does not demand a certain location of curly braces
 the following two cases will not produce a violation):
 
-    {100000000000000000000,
-     200000000000000000000,} // Trailing comma not needed, line needs to be modified anyway
+``` 
+{100000000000000000000,
+ 200000000000000000000,} // Trailing comma not needed, line needs to be modified anyway
 
-    {100000000000000000000,
-     200000000000000000000, // Modified line
-     300000000000000000000,} // Added line
-            
+{100000000000000000000,
+ 200000000000000000000, // Modified line
+ 300000000000000000000,} // Added line
+        
+```
 
 If opening brace is on the same line as trailing comma there's also
 (more arguable) problem:
 
-    {100000000000000000000, // Line cannot be just duplicated to slightly modify entry
-    }
+``` 
+{100000000000000000000, // Line cannot be just duplicated to slightly modify entry
+}
 
-    {100000000000000000000,
-     100000000000000000001, // More work needed to duplicate
-    }
+{100000000000000000000,
+ 100000000000000000001, // More work needed to duplicate
+}
+        
+```

--- a/docs/description/ArrayTypeStyle.md
+++ b/docs/description/ArrayTypeStyle.md
@@ -1,10 +1,10 @@
 Checks the style of array type definitions. Some like Java style:
-`public static void main(String[] args)` and some like C style:
-`public static void main(String args[])`.
+`public static void main(String[] args)` and some like C style: `public
+static void main(String args[])`.
 
 By default the Check enforces Java style.
 
 This check strictly enforces only Java style for method return types
-regardless of the value for 'javaStyle'. For example,
-`byte[] getData()`. This is because C doesn't compile methods with array
+regardless of the value for 'javaStyle'. For example, `byte[]
+getData()`. This is because C doesn't compile methods with array
 declarations on the name.

--- a/docs/description/AvoidInlineConditionals.md
+++ b/docs/description/AvoidInlineConditionals.md
@@ -1,9 +1,11 @@
 Detects inline conditionals. Here is one example of an inline
 conditional:
 
-    String a = getParameter("a");
-    String b = (a==null || a.length()<1) ? null : a.substring(1);
-            
+``` 
+String a = getParameter("a");
+String b = (a==null || a.length()<1) ? null : a.substring(1);
+        
+```
 
 Rationale: Some developers find inline conditionals hard to read, so
 their employer's coding standards forbid them.

--- a/docs/description/AvoidNestedBlocks.md
+++ b/docs/description/AvoidNestedBlocks.md
@@ -5,23 +5,27 @@ they confuse the reader.
 
 For example, this check finds the obsolete braces in
 
-    public void guessTheOutput()
-    {
-      int whichIsWhich = 0;
-      {
-        whichIsWhich = 2;
-      }
-      System.out.println("value = " + whichIsWhich);
-    }
-            
+``` 
+public void guessTheOutput()
+{
+  int whichIsWhich = 0;
+  {
+    whichIsWhich = 2;
+  }
+  System.out.println("value = " + whichIsWhich);
+}
+        
+```
 
 and debugging / refactoring leftovers such as
 
-    // if (conditionThatIsNotUsedAnyLonger)
-    {
-      System.out.println("unconditional");
-    }
-            
+``` 
+// if (conditionThatIsNotUsedAnyLonger)
+{
+  System.out.println("unconditional");
+}
+        
+```
 
 A case in a switch statement does not implicitly form a block. Thus to
 be able to introduce local variables that have case scope it is

--- a/docs/description/CatchParameterName.md
+++ b/docs/description/CatchParameterName.md
@@ -2,12 +2,12 @@ Checks that `catch` parameter names conform to a specified pattern.
 
 Default pattern has the following characteristic:
 
--   allows names beginning with two lowercase letters followed by at
+  - allows names beginning with two lowercase letters followed by at
     least one uppercase or lowercase letter
--   allows `e` abbreviation (suitable for exceptions end errors)
--   allows `ex` abbreviation (suitable for exceptions)
--   allows `t` abbreviation (suitable for throwables)
--   prohibits numbered abbreviations like `e1` or `t2`
--   prohibits one letter prefixes like `pException`
--   prohibits two letter abbreviations like `ie` or `ee`
--   prohibits any other characters than letters
+  - allows `e` abbreviation (suitable for exceptions end errors)
+  - allows `ex` abbreviation (suitable for exceptions)
+  - allows `t` abbreviation (suitable for throwables)
+  - prohibits numbered abbreviations like `e1` or `t2`
+  - prohibits one letter prefixes like `pException`
+  - prohibits two letter abbreviations like `ie` or `ee`
+  - prohibits any other characters than letters

--- a/docs/description/ClassDataAbstractionCoupling.md
+++ b/docs/description/ClassDataAbstractionCoupling.md
@@ -9,17 +9,17 @@ This check processes files in the following way:
 
 1.  Iterates over the list of tokens (defined below) and counts all
     mentioned classes.
-    -   [PACKAGE_DEF](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT)
-    -   [IMPORT](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT)
-    -   [CLASS_DEF](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF)
-    -   [INTERFACE_DEF](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF)
-    -   [ENUM_DEF](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF)
-    -   [LITERAL_NEW](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW)
-    -   [RECORD_DEF](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF)
-2.  If a class was imported with direct import (i.e.
-    `import java.math.BigDecimal`), or the class was referenced with the
-    package name (i.e. `java.math.BigDecimal value`) and the package was
-    added to the `excludedPackages` parameter, the class does not
-    increase complexity.
+      - [PACKAGE\_DEF](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT)
+      - [IMPORT](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT)
+      - [CLASS\_DEF](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF)
+      - [INTERFACE\_DEF](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF)
+      - [ENUM\_DEF](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF)
+      - [LITERAL\_NEW](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW)
+      - [RECORD\_DEF](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF)
+2.  If a class was imported with direct import (i.e. `import
+    java.math.BigDecimal`), or the class was referenced with the package
+    name (i.e. `java.math.BigDecimal value`) and the package was added
+    to the `excludedPackages` parameter, the class does not increase
+    complexity.
 3.  If a class name was added to the `excludedClasses` parameter, the
     class does not increase complexity.

--- a/docs/description/ClassFanOutComplexity.md
+++ b/docs/description/ClassFanOutComplexity.md
@@ -6,10 +6,10 @@ functional programs (on a file basis) at least.
 This check processes files in the following way:
 
 1.  Iterates over all tokens that might contain type reference.
-2.  If a class was imported with direct import (i.e.
-    `import java.math.BigDecimal`), or the class was referenced with the
-    package name (i.e. `java.math.BigDecimal value`) and the package was
-    added to the `excludedPackages` parameter, the class does not
-    increase complexity.
+2.  If a class was imported with direct import (i.e. `import
+    java.math.BigDecimal`), or the class was referenced with the package
+    name (i.e. `java.math.BigDecimal value`) and the package was added
+    to the `excludedPackages` parameter, the class does not increase
+    complexity.
 3.  If a class name was added to the `excludedClasses` parameter, the
     class does not increase complexity.

--- a/docs/description/ClassMemberImpliedModifier.md
+++ b/docs/description/ClassMemberImpliedModifier.md
@@ -11,12 +11,14 @@ and as such the compiler does not require the `static` modifier. This
 check provides the ability to enforce that the `static` modifier is
 explicitly coded and not implicitly added by the compiler.
 
-    public final class Person {
-      enum Age {  // violation
-        CHILD, ADULT
-      }
-    }
-            
+``` 
+public final class Person {
+  enum Age {  // violation
+    CHILD, ADULT
+  }
+}
+        
+```
 
 Rationale for this check: Nested enums, interfaces, and records are
 treated differently from nested classes as they are only allowed to be

--- a/docs/description/CommentsIndentation.md
+++ b/docs/description/CommentsIndentation.md
@@ -6,67 +6,75 @@ about such convention can be found
 Please take a look at the following examples to understand how the check
 works:
 
-Example #1: Block comments.
+Example \#1: Block comments.
 
-    1   /*
-    2    * it is Ok
-    3    */
-    4   boolean bool = true;
-    5
-    6     /* violation
-    7      * (block comment should have the same indentation level as line 9)
-    8      */
-    9   double d = 3.14;
-            
+``` 
+1   /*
+2    * it is Ok
+3    */
+4   boolean bool = true;
+5
+6     /* violation
+7      * (block comment should have the same indentation level as line 9)
+8      */
+9   double d = 3.14;
+        
+```
 
-Example #2: Comment is placed at the end of the block and has previous
+Example \#2: Comment is placed at the end of the block and has previous
 statement.
 
-    1   public void foo1() {
-    2     foo2();
-    3     // it is OK
-    4   }
-    5
-    6   public void foo2() {
-    7     foo3();
-    8       // violation (comment should have the same indentation level as line 7)
-    9   }
-            
+``` 
+1   public void foo1() {
+2     foo2();
+3     // it is OK
+4   }
+5
+6   public void foo2() {
+7     foo3();
+8       // violation (comment should have the same indentation level as line 7)
+9   }
+        
+```
 
-Example #3: Comment is used as a single line border to separate groups
+Example \#3: Comment is used as a single line border to separate groups
 of methods.
 
-    1   /////////////////////////////// it is OK
-    2
-    3   public void foo7() {
-    4     int a = 0;
-    5   }
-    6
-    7     ///////////////////////////// violation (should have the same indentation level as line 9)
-    8
-    9   public void foo8() {}
-            
+``` 
+1   /////////////////////////////// it is OK
+2
+3   public void foo7() {
+4     int a = 0;
+5   }
+6
+7     ///////////////////////////// violation (should have the same indentation level as line 9)
+8
+9   public void foo8() {}
+        
+```
 
-Example #4: Comment has distributed previous statement.
+Example \#4: Comment has distributed previous statement.
 
-    1   public void foo11() {
-    2     CheckUtil
-    3       .getFirstNode(new DetailAST())
-    4       .getFirstChild()
-    5       .getNextSibling();
-    6     // it is OK
-    7   }
-    8
-    9   public void foo12() {
-    10    CheckUtil
-    11      .getFirstNode(new DetailAST())
-    12      .getFirstChild()
-    13      .getNextSibling();
-    14              // violation (should have the same indentation level as line 10)
-    15  }
-            
+``` 
+1   public void foo11() {
+2     CheckUtil
+3       .getFirstNode(new DetailAST())
+4       .getFirstChild()
+5       .getNextSibling();
+6     // it is OK
+7   }
+8
+9   public void foo12() {
+10    CheckUtil
+11      .getFirstNode(new DetailAST())
+12      .getFirstChild()
+13      .getNextSibling();
+14              // violation (should have the same indentation level as line 10)
+15  }
+        
+```
 
-Example #5: Single line block comment is placed within an empty code
+Example \#5: Single line block comment is placed within an empty code
 block. Note, if comment is placed at the end of the empty code block, we
 have Checkstyle's limitations to clearly detect user intention of
 explanation target - above or below. The only case we can assume as a
@@ -74,101 +82,114 @@ violation is when a single line comment within the empty code block has
 indentation level that is lower than the indentation level of the
 closing right curly brace.
 
-    1   public void foo46() {
-    2     // comment
-    3     // block
-    4     // it is OK (we cannot clearly detect user intention of explanation target)
-    5   }
-    6
-    7   public void foo46() {
-    8  // comment
-    9  // block
-    10 // violation (comment should have the same indentation level as line 11)
-    11  }
-            
+``` 
+1   public void foo46() {
+2     // comment
+3     // block
+4     // it is OK (we cannot clearly detect user intention of explanation target)
+5   }
+6
+7   public void foo46() {
+8  // comment
+9  // block
+10 // violation (comment should have the same indentation level as line 11)
+11  }
+        
+```
 
-Example #6: 'fallthrough' comments and similar.
+Example \#6: 'fallthrough' comments and similar.
 
-    0   switch(a) {
-    1     case "1":
-    2       int k = 7;
-    3       // it is OK
-    4     case "2":
-    5       int k = 7;
-    6     // it is OK
-    7     case "3":
-    8       if (true) {}
-    9           // violation (should have the same indentation level as line 8 or 10)
-    10    case "4":
-    11    case "5": {
-    12      int a;
-    13    }
-    14    // fall through (it is OK)
-    15    case "12": {
-    16      int a;
-    17    }
-    18    default:
-    19      // it is OK
-    20  }
-            
+``` 
+0   switch(a) {
+1     case "1":
+2       int k = 7;
+3       // it is OK
+4     case "2":
+5       int k = 7;
+6     // it is OK
+7     case "3":
+8       if (true) {}
+9           // violation (should have the same indentation level as line 8 or 10)
+10    case "4":
+11    case "5": {
+12      int a;
+13    }
+14    // fall through (it is OK)
+15    case "12": {
+16      int a;
+17    }
+18    default:
+19      // it is OK
+20  }
+        
+```
 
-Example #7: Comment is placed within a distributed statement.
+Example \#7: Comment is placed within a distributed statement.
 
-    1   String breaks = "J"
-    2   // violation (comment should have the same indentation level as line 3)
-    3       + "A"
-    4       // it is OK
-    5       + "V"
-    6       + "A"
-    7   // it is OK
-    8   ;
-            
+``` 
+1   String breaks = "J"
+2   // violation (comment should have the same indentation level as line 3)
+3       + "A"
+4       // it is OK
+5       + "V"
+6       + "A"
+7   // it is OK
+8   ;
+        
+```
 
-Example #8: Comment is placed within an empty case block. Note, if
+Example \#8: Comment is placed within an empty case block. Note, if
 comment is placed at the end of the empty case block, we have
 Checkstyle's limitations to clearly detect user intention of explanation
 target - above or below. The only case we can assume as a violation is
 when a single line comment within the empty case block has indentation
 level that is lower than the indentation level of the next case token.
 
-    1   case 4:
-    2     // it is OK
-    3   case 5:
-    4  // violation (should have the same indentation level as line 3 or 5)
-    5   case 6:
-            
+``` 
+1   case 4:
+2     // it is OK
+3   case 5:
+4  // violation (should have the same indentation level as line 3 or 5)
+5   case 6:
+        
+```
 
-Example #9: Single line block comment has previous and next statement.
+Example \#9: Single line block comment has previous and next statement.
 
-    1   String s1 = "Clean code!";
-    2      s.toString().toString().toString();
-    3   // single line
-    4   // block
-    5   // comment (it is OK)
-    6   int a = 5;
-    7
-    8   String s2 = "Code complete!";
-    9    s.toString().toString().toString();
-    10            // violation (should have the same indentation level as line 11)
-    11       // violation (should have the same indentation level as line 12)
-    12     // violation (should have the same indentation level as line 13)
-    13  int b = 18;
-            
+``` 
+1   String s1 = "Clean code!";
+2      s.toString().toString().toString();
+3   // single line
+4   // block
+5   // comment (it is OK)
+6   int a = 5;
+7
+8   String s2 = "Code complete!";
+9    s.toString().toString().toString();
+10            // violation (should have the same indentation level as line 11)
+11       // violation (should have the same indentation level as line 12)
+12     // violation (should have the same indentation level as line 13)
+13  int b = 18;
+        
+```
 
-Example #10: Comment within the block tries to describe the next code
+Example \#10: Comment within the block tries to describe the next code
 block.
 
-    1   public void foo42() {
-    2     int a = 5;
-    3     if (a == 5) {
-    4       int b;
-    5       // it is OK
-    6      } else if (a ==6) { ... }
-    7   }
-    8
-    9   public void foo43() {
-    10    try {
-    11      int a;
-    12     // Why do we catch exception here? - violation (not the same indentation as line 11)
-    13     } catch (Exception e) { ... }
-    14  }
+``` 
+1   public void foo42() {
+2     int a = 5;
+3     if (a == 5) {
+4       int b;
+5       // it is OK
+6      } else if (a ==6) { ... }
+7   }
+8
+9   public void foo43() {
+10    try {
+11      int a;
+12     // Why do we catch exception here? - violation (not the same indentation as line 11)
+13     } catch (Exception e) { ... }
+14  }
+        
+```

--- a/docs/description/CovariantEquals.md
+++ b/docs/description/CovariantEquals.md
@@ -21,8 +21,10 @@ containers.
 Programmers sometimes mistakenly use the type of their class `Foo` as
 the type of the parameter to `equals()`:
 
-    public boolean equals(Foo obj) {...}
-            
+``` 
+public boolean equals(Foo obj) {...}
+        
+```
 
 This covariant version of `equals()` does not override the version in
 the `Object` class, and it may lead to unexpected behavior at runtime,

--- a/docs/description/CyclomaticComplexity.md
+++ b/docs/description/CyclomaticComplexity.md
@@ -1,10 +1,10 @@
 Checks cyclomatic complexity against a specified limit. It is a measure
 of the minimum number of possible paths through the source and therefore
-the number of required tests, it is not a about quality of code! It is
+the number of required tests, it is not a about quality of code\! It is
 only applied to methods, c-tors, [static initializers and instance
 initializers](https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html).
 
-The complexity is equal to the number of decision points ` + 1`.
+The complexity is equal to the number of decision points `  + 1 `.
 Decision points: `if`, `while` , `do`, `for`, `?:`, `catch` , `switch`,
 `case` statements and operators `&&` and `||` in the body of target.
 

--- a/docs/description/DeclarationOrder.md
+++ b/docs/description/DeclarationOrder.md
@@ -26,8 +26,11 @@ from validation due to the fact that we have Checkstyle's limitations to
 clearly detect user intention of fields location and grouping. For
 example:
 
-    public class A {
-      private double x = 1.0;
-      private double y = 2.0;
-      public double slope = x / y; // will be skipped from validation due to forward reference
-    }
+``` 
+public class A {
+  private double x = 1.0;
+  private double y = 2.0;
+  public double slope = x / y; // will be skipped from validation due to forward reference
+}
+        
+```

--- a/docs/description/DesignForExtension.md
+++ b/docs/description/DesignForExtension.md
@@ -64,46 +64,51 @@ provide empty "hooks" that can be implemented by subclasses.
 
 Example of code that cause violation as it is designed for extension:
 
-    public abstract class Plant {
-      private String roots;
-      private String trunk;
+``` 
+public abstract class Plant {
+  private String roots;
+  private String trunk;
 
-      protected void validate() {
-        if (roots == null) throw new IllegalArgumentException("No roots!");
-        if (trunk == null) throw new IllegalArgumentException("No trunk!");
-      }
+  protected void validate() {
+    if (roots == null) throw new IllegalArgumentException("No roots!");
+    if (trunk == null) throw new IllegalArgumentException("No trunk!");
+  }
 
-      public abstract void grow();
-    }
+  public abstract void grow();
+}
 
-    public class Tree extends Plant {
-      private List leaves;
+public class Tree extends Plant {
+  private List leaves;
 
-      @Overrides
-      protected void validate() {
-        super.validate();
-        if (leaves == null) throw new IllegalArgumentException("No leaves!");
-      }
+  @Overrides
+  protected void validate() {
+    super.validate();
+    if (leaves == null) throw new IllegalArgumentException("No leaves!");
+  }
 
-      public void grow() {
-        validate();
-      }
-    }
-            
+  public void grow() {
+    validate();
+  }
+}
+        
+```
 
 Example of code without violation:
 
-    public abstract class Plant {
-      private String roots;
-      private String trunk;
+``` 
+public abstract class Plant {
+  private String roots;
+  private String trunk;
 
-      private void validate() {
-        if (roots == null) throw new IllegalArgumentException("No roots!");
-        if (trunk == null) throw new IllegalArgumentException("No trunk!");
-        validateEx();
-      }
+  private void validate() {
+    if (roots == null) throw new IllegalArgumentException("No roots!");
+    if (trunk == null) throw new IllegalArgumentException("No trunk!");
+    validateEx();
+  }
 
-      protected void validateEx() { }
+  protected void validateEx() { }
 
-      public abstract void grow();
-    }
+  public abstract void grow();
+}
+        
+```

--- a/docs/description/EmptyBlock.md
+++ b/docs/description/EmptyBlock.md
@@ -2,14 +2,16 @@ Checks for empty blocks. This check does not validate sequential blocks.
 
 Sequential blocks won't be checked. Also, no violations for fallthrough:
 
-    switch (a) {
-      case 1:                          // no violation
-      case 2:                          // no violation
-      case 3: someMethod(); { }        // no violation
-      default: break;
-    }
-            
+``` 
+switch (a) {
+  case 1:                          // no violation
+  case 2:                          // no violation
+  case 3: someMethod(); { }        // no violation
+  default: break;
+}
+        
+```
 
-NOTE: This check processes LITERAL_CASE and LITERAL_DEFAULT separately.
-Verification empty block is done for single most nearest {@code case} or
-{@code default}.
+NOTE: This check processes LITERAL\_CASE and LITERAL\_DEFAULT
+separately. Verification empty block is done for single most nearest
+{@code case} or {@code default}.

--- a/docs/description/EmptyForInitializerPad.md
+++ b/docs/description/EmptyForInitializerPad.md
@@ -3,5 +3,8 @@ space is required at an empty for initializer, or such white space is
 forbidden. No check occurs if there is a line wrap at the initializer,
 as in
 
-    for (
-          ; i < j; i++, j--)
+``` 
+for (
+      ; i < j; i++, j--)
+        
+```

--- a/docs/description/EmptyForIteratorPad.md
+++ b/docs/description/EmptyForIteratorPad.md
@@ -3,6 +3,9 @@ space is required at an empty for iterator, or such white space is
 forbidden. No check occurs if there is a line wrap at the iterator, as
 in
 
-    for (Iterator foo = very.long.line.iterator();
-          foo.hasNext();
-         )
+``` 
+for (Iterator foo = very.long.line.iterator();
+      foo.hasNext();
+     )
+        
+```

--- a/docs/description/EmptyLineSeparator.md
+++ b/docs/description/EmptyLineSeparator.md
@@ -8,7 +8,7 @@ implementation and documentation comments and blocks as well.
 ATTENTION: empty line separator is required between token siblings, not
 after line where token is found. If token does not have same type
 sibling then empty line is required at its end (for example for
-CLASS_DEF it is after '}'). Also, trailing comments are skipped.
+CLASS\_DEF it is after '}'). Also, trailing comments are skipped.
 
 ATTENTION: violations from multiple empty lines cannot be suppressed via
-XPath: [#8179](https://github.com/checkstyle/checkstyle/issues/8179).
+XPath: [\#8179](https://github.com/checkstyle/checkstyle/issues/8179).

--- a/docs/description/FileTabCharacter.md
+++ b/docs/description/FileTabCharacter.md
@@ -2,8 +2,8 @@ Checks that there are no tab characters (`'\t'`) in the source code.
 
 Rationale:
 
--   Developers should not need to configure the tab width of their text
+  - Developers should not need to configure the tab width of their text
     editors in order to be able to read source code.
--   From the Apache jakarta coding standards: In a distributed
+  - From the Apache jakarta coding standards: In a distributed
     development environment, when the commit messages get sent to a
     mailing list, they are almost impossible to read if you use tabs.

--- a/docs/description/GenericWhitespace.md
+++ b/docs/description/GenericWhitespace.md
@@ -1,18 +1,18 @@
 Checks that the whitespace around the Generic tokens (angle brackets)
-"\<" and ">" are correct to the *typical* convention. The convention is
+"\<" and "\>" are correct to the *typical* convention. The convention is
 not configurable.
 
 Left angle bracket ("\<"):
 
--   should be preceded with whitespace only in generic methods
+  - should be preceded with whitespace only in generic methods
     definitions.
--   should not be preceded with whitespace when it is precede method
+  - should not be preceded with whitespace when it is precede method
     name or constructor.
--   should not be preceded with whitespace when following type name.
--   should not be followed with whitespace in all cases.
+  - should not be preceded with whitespace when following type name.
+  - should not be followed with whitespace in all cases.
 
-Right angle bracket (">"):
+Right angle bracket ("\>"):
 
--   should not be preceded with whitespace in all cases.
--   should be followed with whitespace in almost all cases, except
+  - should not be preceded with whitespace in all cases.
+  - should be followed with whitespace in almost all cases, except
     diamond operators and when preceding method name or constructor.

--- a/docs/description/Header.md
+++ b/docs/description/Header.md
@@ -8,12 +8,14 @@ matching lines in a header file. This property is very useful for
 supporting headers that contain copyright dates. For example, consider
 the following header:
 
-    line 1: ////////////////////////////////////////////////////////////////////
-    line 2: // checkstyle:
-    line 3: // Checks Java source code for adherence to a set of rules.
-    line 4: // Copyright (C) 2002  Oliver Burn
-    line 5: ////////////////////////////////////////////////////////////////////
-            
+``` 
+line 1: ////////////////////////////////////////////////////////////////////
+line 2: // checkstyle:
+line 3: // Checks Java source code for adherence to a set of rules.
+line 4: // Copyright (C) 2002  Oliver Burn
+line 5: ////////////////////////////////////////////////////////////////////
+        
+```
 
 Since the year information will change over time, you can tell
 Checkstyle to ignore line 4 by setting property `ignoreLines` to `4`.

--- a/docs/description/HideUtilityClassConstructor.md
+++ b/docs/description/HideUtilityClassConstructor.md
@@ -10,14 +10,17 @@ If you make the constructor protected you may want to consider the
 following constructor implementation technique to disallow instantiating
 subclasses:
 
-    public class StringUtils // not final to allow subclassing
-    {
-      protected StringUtils() {
-        // prevents calls from subclass
-        throw new UnsupportedOperationException();
-      }
+``` 
+public class StringUtils // not final to allow subclassing
+{
+  protected StringUtils() {
+    // prevents calls from subclass
+    throw new UnsupportedOperationException();
+  }
 
-      public static int count(char c, String s) {
-        // ...
-      }
-    }
+  public static int count(char c, String s) {
+    // ...
+  }
+}
+        
+```

--- a/docs/description/IllegalInstantiation.md
+++ b/docs/description/IllegalInstantiation.md
@@ -5,7 +5,7 @@ preferable to create instances through factory methods rather than
 calling the constructor.
 
 A simple example is the `java.lang.Boolean` class. For performance
-reasons, it is preferable to use the predefined constants ` TRUE` and
+reasons, it is preferable to use the predefined constants `  TRUE ` and
 `FALSE`. Constructor invocations should be replaced by calls to
 `Boolean.valueOf()`.
 

--- a/docs/description/ImportControl.md
+++ b/docs/description/ImportControl.md
@@ -13,33 +13,33 @@ extension is ignored.
 
 Short description of the behaviour:
 
--   Check starts checking from the longest matching subpackage (later
+  - Check starts checking from the longest matching subpackage (later
     'current subpackage') or the first file name match described inside
     import control file to package defined in class file.
-    -   The longest matching subpackage is found by starting with the
+      - The longest matching subpackage is found by starting with the
         root package and examining if the any of the sub-packages or
         file definitions match the current class' package or file name.
-    -   If a file name is matched first, that is considered the longest
+      - If a file name is matched first, that is considered the longest
         match and becomes the current file/subpackage.
-    -   If another subpackage is matched, then it's subpackages and file
+      - If another subpackage is matched, then it's subpackages and file
         names are examined for the next longest match and the process
         repeats recursively.
-    -   If no subpackages or file names are matched, the current
+      - If no subpackages or file names are matched, the current
         subpackage is then used.
--   Order of rules in the same subpackage/root are defined by the order
+  - Order of rules in the same subpackage/root are defined by the order
     of declaration in the XML file, which is from top (first) to bottom
     (last).
--   If there is matching allow/disallow rule inside the current
+  - If there is matching allow/disallow rule inside the current
     file/subpackage then the Check returns the first "allowed" or
     "disallowed" message.
--   If there is no matching allow/disallow rule inside the current
+  - If there is no matching allow/disallow rule inside the current
     file/subpackage then it continues checking in the parent subpackage.
--   If there is no matching allow/disallow rule in any of the
+  - If there is no matching allow/disallow rule in any of the
     files/subpackages, including the root level (import-control), then
     the import is disallowed by default.
 
 The DTD for a import control XML document is at
-[https://checkstyle.org/dtds/import_control_1\_4.dtd](/dtds/import_control_1_4.dtd).
+[https://checkstyle.org/dtds/import\_control\_1\_4.dtd](/dtds/import_control_1_4.dtd).
 It contains documentation on each of the elements and attributes.
 
 The check validates a XML document when it loads the document. To
@@ -48,9 +48,11 @@ declaration in your XML document:
 
 <div class="wrapper">
 
-    <!DOCTYPE import-control PUBLIC
-        "-//Checkstyle//DTD ImportControl Configuration 1.4//EN"
-        "https://checkstyle.org/dtds/import_control_1_4.dtd">
-              
+``` 
+<!DOCTYPE import-control PUBLIC
+    "-//Checkstyle//DTD ImportControl Configuration 1.4//EN"
+    "https://checkstyle.org/dtds/import_control_1_4.dtd">
+          
+```
 
 </div>

--- a/docs/description/ImportOrder.md
+++ b/docs/description/ImportOrder.md
@@ -1,17 +1,17 @@
 Checks the ordering/grouping of imports. Features are:
 
--   groups type/static imports: ensures that groups of imports come in a
+  - groups type/static imports: ensures that groups of imports come in a
     specific order (e.g., java. comes first, javax. comes second, then
     everything else)
--   adds a separation between type import groups : ensures that a blank
+  - adds a separation between type import groups : ensures that a blank
     line sit between each group
--   type/static import groups aren't separated internally: ensures that
+  - type/static import groups aren't separated internally: ensures that
     each group aren't separated internally by blank line or comment
--   sorts type/static imports inside each group: ensures that imports
+  - sorts type/static imports inside each group: ensures that imports
     within each group are in lexicographic order
--   sorts according to case: ensures that the comparison between imports
+  - sorts according to case: ensures that the comparison between imports
     is case sensitive, in [ASCII sort
     order](https://en.wikipedia.org/wiki/ASCII#Order)
--   arrange static imports: ensures the relative order between type
+  - arrange static imports: ensures the relative order between type
     imports and static imports (see
     [ImportOrderOption](https://checkstyle.org/property_types.html#ImportOrderOption))

--- a/docs/description/Indentation.md
+++ b/docs/description/Indentation.md
@@ -20,12 +20,15 @@ increased on top of the line wrap and any indentations above it.
 
 Example:
 
-    if ((condition1 && condition2)
-            || (condition3 && condition4)    // line wrap with bigger indentation
-            ||!(condition5 && condition6)) { // line wrap with bigger indentation
-      field.doSomething()                    // basic offset
-          .doSomething()                     // line wrap
-          .doSomething( c -> {               // line wrap
-            return c.doSome();               // basic offset
-          });
-    }
+``` 
+if ((condition1 && condition2)
+        || (condition3 && condition4)    // line wrap with bigger indentation
+        ||!(condition5 && condition6)) { // line wrap with bigger indentation
+  field.doSomething()                    // basic offset
+      .doSomething()                     // line wrap
+      .doSomething( c -> {               // line wrap
+        return c.doSome();               // basic offset
+      });
+}
+        
+```

--- a/docs/description/InnerAssignment.md
+++ b/docs/description/InnerAssignment.md
@@ -1,5 +1,5 @@
-Checks for assignments in subexpressions, such as in
-`String s = Integer.toString(i = 2);`.
+Checks for assignments in subexpressions, such as in `String s =
+Integer.toString(i = 2);`.
 
 Rationale: With the exception of loop idioms, all assignments should
 occur in their own top-level statement to increase readability. With
@@ -8,22 +8,24 @@ places where a variable is set.
 
 Note: Check allows usage of the popular assignments in loops:
 
-    String line;
-    while ((line = bufferedReader.readLine()) != null) { // OK
-      // process the line
-    }
+``` 
+String line;
+while ((line = bufferedReader.readLine()) != null) { // OK
+  // process the line
+}
 
-    for (;(line = bufferedReader.readLine()) != null;) { // OK
-      // process the line
-    }
+for (;(line = bufferedReader.readLine()) != null;) { // OK
+  // process the line
+}
 
-    do {
-      // process the line
-    }
-    while ((line = bufferedReader.readLine()) != null); // OK
-            
+do {
+  // process the line
+}
+while ((line = bufferedReader.readLine()) != null); // OK
+        
+```
 
 Assignment inside a condition is not a problem here, as the assignment
-is surrounded by an extra pair of parentheses. The comparison is
-`!= null` and there is no chance that intention was to write
-`line == reader.readLine()`.
+is surrounded by an extra pair of parentheses. The comparison is `!=
+null` and there is no chance that intention was to write `line ==
+reader.readLine()`.

--- a/docs/description/InterfaceMemberImpliedModifier.md
+++ b/docs/description/InterfaceMemberImpliedModifier.md
@@ -27,30 +27,32 @@ the compiler does not require the `public static` modifiers. This check
 provides the ability to enforce that the `public` and `static` modifiers
 are explicitly coded and not implicitly added by the compiler.
 
-    public interface AddressFactory {
-      // check enforces code contains "public static final"
-      public static final String UNKNOWN = "Unknown";
+``` 
+public interface AddressFactory {
+  // check enforces code contains "public static final"
+  public static final String UNKNOWN = "Unknown";
 
-      String OTHER = "Other";  // violation
+  String OTHER = "Other";  // violation
 
-      // check enforces code contains "public" or "private"
-      public static AddressFactory instance();
+  // check enforces code contains "public" or "private"
+  public static AddressFactory instance();
 
-      // check enforces code contains "public abstract"
-      public abstract Address createAddress(String addressLine, String city);
+  // check enforces code contains "public abstract"
+  public abstract Address createAddress(String addressLine, String city);
 
-      List<Address> findAddresses(String city);  // violation
+  List<Address> findAddresses(String city);  // violation
 
-      // check enforces default methods are explicitly declared "public"
-      public default Address createAddress(String city) {
-        return createAddress(UNKNOWN, city);
-      }
+  // check enforces default methods are explicitly declared "public"
+  public default Address createAddress(String city) {
+    return createAddress(UNKNOWN, city);
+  }
 
-      default Address createOtherAddress() {  // violation
-        return createAddress(OTHER, OTHER);
-      }
-    }
-            
+  default Address createOtherAddress() {  // violation
+    return createAddress(OTHER, OTHER);
+  }
+}
+        
+```
 
 Rationale for this check: Methods, fields and nested types are treated
 differently depending on whether they are part of an interface or part

--- a/docs/description/JavadocContentLocation.md
+++ b/docs/description/JavadocContentLocation.md
@@ -4,18 +4,23 @@ not counted as the beginning of the content and are therefore ignored.
 
 It is possible to enforce two different styles:
 
--   {@code first_line} - Javadoc content starts from the first line:
+  - {@code first\_line} - Javadoc content starts from the first line:
+    
+    ``` 
+    /** Summary text.
+      * More details.
+      */
+    public void method();
+                
+    ```
 
-        /** Summary text.
-          * More details.
-          */
-        public void method();
-                    
-
--   {@code second_line} - Javadoc content starts from the second line:
-
-        /**
-          * Summary text.
-          * More details.
-          */
-        public void method();
+  - {@code second\_line} - Javadoc content starts from the second line:
+    
+    ``` 
+    /**
+      * Summary text.
+      * More details.
+      */
+    public void method();
+                
+    ```

--- a/docs/description/JavadocMethod.md
+++ b/docs/description/JavadocMethod.md
@@ -11,12 +11,12 @@ method signature or by `throw new` in the method body), but for which no
 throws tag is present by activation of property `validateThrows`. Note
 that `throw new` is not checked in the following places:
 
--   Inside a try block (with catch). It is not possible to determine if
+  - Inside a try block (with catch). It is not possible to determine if
     the thrown exception can be caught by the catch block as there is no
     knowledge of the inheritance hierarchy, so the try block is ignored
     entirely. However, catch and finally blocks, as well as try blocks
     without catch, are still checked.
--   Local classes, anonymous classes and lambda expressions. It is not
+  - Local classes, anonymous classes and lambda expressions. It is not
     known when the throw statements inside such classes are going to be
     evaluated, so they are ignored.
 
@@ -38,7 +38,10 @@ private non-static methods and constructors are not inheritable.
 For example, if the following method is implementing a method required
 by an interface, then the Javadoc could be done as:
 
-    /** {@inheritDoc} */
-    public int checkReturnTag(final int aTagIndex,
-                              JavadocTag[] aTags,
-                              int aLineNo)
+``` 
+/** {@inheritDoc} */
+public int checkReturnTag(final int aTagIndex,
+                          JavadocTag[] aTags,
+                          int aLineNo)
+        
+```

--- a/docs/description/JavadocParagraph.md
+++ b/docs/description/JavadocParagraph.md
@@ -2,6 +2,6 @@ Checks the Javadoc paragraph.
 
 Checks that:
 
--   There is one blank line between each of two paragraphs.
--   Each paragraph but the first has \<p> immediately before the first
+  - There is one blank line between each of two paragraphs.
+  - Each paragraph but the first has \<p\> immediately before the first
     word, with no space after.

--- a/docs/description/JavadocStyle.md
+++ b/docs/description/JavadocStyle.md
@@ -2,22 +2,22 @@ Validates Javadoc comments to help ensure they are well formed.
 
 The following checks are performed:
 
--   Ensures the first sentence ends with proper punctuation (That is a
+  - Ensures the first sentence ends with proper punctuation (That is a
     period, question mark, or exclamation mark, by default). Javadoc
     automatically places the first sentence in the method summary table
     and index. Without proper punctuation the Javadoc may be malformed.
     All items eligible for the `{@inheritDoc}` tag are exempt from this
     requirement.
--   Check text for Javadoc statements that do not have any description.
+  - Check text for Javadoc statements that do not have any description.
     This includes both completely empty Javadoc, and Javadoc with only
     tags such as `@param` and `@return`.
--   Check text for incomplete HTML tags. Verifies that HTML tags have
+  - Check text for incomplete HTML tags. Verifies that HTML tags have
     corresponding end tags and issues an "Unclosed HTML tag found:"
     error if not. An "Extra HTML tag found:" error is issued if an end
     tag is found without a previous open tag.
--   Check that a package Javadoc comment is well-formed (as described
+  - Check that a package Javadoc comment is well-formed (as described
     above) and NOT missing from any package-info.java files.
--   Check for allowed HTML tags. The list of allowed HTML tags is "a",
+  - Check for allowed HTML tags. The list of allowed HTML tags is "a",
     "abbr", "acronym", "address", "area", "b", "bdo", "big",
     "blockquote", "br", "caption", "cite", "code", "colgroup", "dd",
     "del", "dfn", "div", "dl", "dt", "em", "fieldset", "font", "h1",

--- a/docs/description/MagicNumber.md
+++ b/docs/description/MagicNumber.md
@@ -8,9 +8,12 @@ Constant definition is any variable/field that has 'final' modifier. It
 is fine to have one constant defining multiple numeric literals within
 one expression:
 
-    static final int SECONDS_PER_DAY = 24 * 60 * 60;
-    static final double SPECIAL_RATIO = 4.0 / 3.0;
-    static final double SPECIAL_SUM = 1 + Math.E;
-    static final double SPECIAL_DIFFERENCE = 4 - Math.PI;
-    static final Border STANDARD_BORDER = BorderFactory.createEmptyBorder(3, 3, 3, 3);
-    static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);
+``` 
+static final int SECONDS_PER_DAY = 24 * 60 * 60;
+static final double SPECIAL_RATIO = 4.0 / 3.0;
+static final double SPECIAL_SUM = 1 + Math.E;
+static final double SPECIAL_DIFFERENCE = 4 - Math.PI;
+static final Border STANDARD_BORDER = BorderFactory.createEmptyBorder(3, 3, 3, 3);
+static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);
+        
+```

--- a/docs/description/MethodCount.md
+++ b/docs/description/MethodCount.md
@@ -16,21 +16,24 @@ Methods defined in anonymous classes are not counted towards any totals.
 Counts only go towards the main type declaration parent, and are kept
 separate from it's children's inner types.
 
-    public class ExampleClass {
-      public enum Colors {
-        RED, GREEN, YELLOW;
+``` 
+public class ExampleClass {
+  public enum Colors {
+    RED, GREEN, YELLOW;
 
-        public String getRGB() { ... } // NOT counted towards ExampleClass
-      }
+    public String getRGB() { ... } // NOT counted towards ExampleClass
+  }
 
-      public void example() { // counted towards ExampleClass
-        Runnable r = (new Runnable() {
-          public void run() { ... } // NOT counted towards ExampleClass, won't produce any violations
-        });
-      }
+  public void example() { // counted towards ExampleClass
+    Runnable r = (new Runnable() {
+      public void run() { ... } // NOT counted towards ExampleClass, won't produce any violations
+    });
+  }
 
-      public static class InnerExampleClass {
-        protected void example2() { ... } // NOT counted towards ExampleClass,
-                                       // but counted towards InnerExampleClass
-      }
-    }
+  public static class InnerExampleClass {
+    protected void example2() { ... } // NOT counted towards ExampleClass,
+                                   // but counted towards InnerExampleClass
+  }
+}
+        
+```

--- a/docs/description/MethodParamPad.md
+++ b/docs/description/MethodParamPad.md
@@ -5,4 +5,4 @@ left parenthesis are on the same line, checks whether a space is
 required immediately after the identifier or such a space is forbidden.
 If they are not on the same line, reports a violation, unless configured
 to allow line breaks. To allow linebreaks after the identifier, set
-property `allowLineBreaks` to `           true`.
+property `allowLineBreaks` to `  true `.

--- a/docs/description/MissingDeprecated.md
+++ b/docs/description/MissingDeprecated.md
@@ -21,8 +21,11 @@ don't want to print violations on package-info, you can use a
 files until the javadoc tool faithfully supports it. An example config
 using SuppressionSingleFilter is:
 
-    <!-- required till https://bugs.openjdk.java.net/browse/JDK-8160601 -->
-    <module name="SuppressionSingleFilter">
-        <property name="checks" value="MissingDeprecatedCheck"/>
-        <property name="files" value="package-info\.java"/>
-    </module>
+``` 
+<!-- required till https://bugs.openjdk.java.net/browse/JDK-8160601 -->
+<module name="SuppressionSingleFilter">
+    <property name="checks" value="MissingDeprecatedCheck"/>
+    <property name="files" value="package-info\.java"/>
+</module>
+        
+```

--- a/docs/description/MissingJavadocMethod.md
+++ b/docs/description/MissingJavadocMethod.md
@@ -12,17 +12,20 @@ Checkstyle supports using the convention of using a single
 For getters and setters for the property `allowMissingPropertyJavadoc`,
 the methods must match exactly the structures below.
 
-    public void setNumber(final int number)
-    {
-        mNumber = number;
-    }
+``` 
+public void setNumber(final int number)
+{
+    mNumber = number;
+}
 
-    public int getNumber()
-    {
-        return mNumber;
-    }
+public int getNumber()
+{
+    return mNumber;
+}
 
-    public boolean isSomething()
-    {
-        return false;
-    }
+public boolean isSomething()
+{
+    return false;
+}
+        
+```

--- a/docs/description/ModifiedControlVariable.md
+++ b/docs/description/ModifiedControlVariable.md
@@ -1,10 +1,12 @@
 Checks that for loop control variables are not modified inside the for
 block. An example is:
 
-    for (int i = 0; i < 1; i++) {
-      i++; // violation
-    }
-            
+``` 
+for (int i = 0; i < 1; i++) {
+  i++; // violation
+}
+        
+```
 
 Rationale: If the control variable is modified inside the loop body, the
 program flow becomes more difficult to follow. See [FOR
@@ -13,14 +15,19 @@ specification for more details.
 
 Such loop would be suppressed:
 
-    for (int i = 0; i < 10;) {
-      i++;
-    }
-            
+``` 
+for (int i = 0; i < 10;) {
+  i++;
+}
+        
+```
 
 NOTE:The check works with only primitive type variables. The check will
 not work for arrays used as control variable.An example is
 
-    for (int a[]={0};a[0] < 10;a[0]++) {
-     a[0]++;   // it will skip this violation
-    }
+``` 
+for (int a[]={0};a[0] < 10;a[0]++) {
+ a[0]++;   // it will skip this violation
+}
+        
+```

--- a/docs/description/NPathComplexity.md
+++ b/docs/description/NPathComplexity.md
@@ -17,15 +17,15 @@ well written and have number of examples and details.
 Here is some quotes:
 
 > An NPATH threshold value of 200 has been established for a function.
-> The value 200 is based on studies done at AT&T Bell Laboratories
+> The value 200 is based on studies done at AT\&T Bell Laboratories
 > \[1988 year\].
 
 > Some of the most effective methods of reducing the NPATH value
 > include:
->
-> -   distributing functionality;
-> -   implementing multiple if statements as a switch statement;
-> -   creating a separate function for logical expressions with a high
+> 
+>   - distributing functionality;
+>   - implementing multiple if statements as a switch statement;
+>   - creating a separate function for logical expressions with a high
 >     count of variables and (&&) and or (||) operators.
 
 > Although strategies to reduce the NPATH complexity of functions are
@@ -113,8 +113,6 @@ Here is some quotes:
 </tbody>
 </table>
 
-Examples
-
 </div>
 
 **Rationale:** Nejmeh says that his group had an informal NPATH limit of
@@ -122,4 +120,4 @@ Examples
 were candidates for further decomposition - or at least a closer look.
 **Please do not be fanatic with limit 200** - choose number that suites
 your project style. Limit 200 is empirical number base on some sources
-of at AT&T Bell Laboratories of 1988 year.
+of at AT\&T Bell Laboratories of 1988 year.

--- a/docs/description/NewlineAtEndOfFile.md
+++ b/docs/description/NewlineAtEndOfFile.md
@@ -6,15 +6,17 @@ and "diff" command does not show previous lines as changed.
 
 Example (line 36 should not be in diff):
 
-    @@ -32,4 +32,5 @@ ForbidWildcardAsReturnTypeCheck.returnTypeClassNamesIgnoreRegex
-    PublicReferenceToPrivateTypeCheck.name = Public Reference To Private Type
+``` 
+@@ -32,4 +32,5 @@ ForbidWildcardAsReturnTypeCheck.returnTypeClassNamesIgnoreRegex
+PublicReferenceToPrivateTypeCheck.name = Public Reference To Private Type
 
-    StaticMethodCandidateCheck.name = Static Method Candidate
-    -StaticMethodCandidateCheck.desc = Checks whether private methods should be declared as static.
-    \ No newline at end of file
-    +StaticMethodCandidateCheck.desc = Checks whether private methods should be declared as static.
-    +StaticMethodCandidateCheck.skippedMethods = Method names to skip during the check.
-            
+StaticMethodCandidateCheck.name = Static Method Candidate
+-StaticMethodCandidateCheck.desc = Checks whether private methods should be declared as static.
+\ No newline at end of file
++StaticMethodCandidateCheck.desc = Checks whether private methods should be declared as static.
++StaticMethodCandidateCheck.skippedMethods = Method names to skip during the check.
+        
+```
 
 It can also trick the VCS to report the wrong owner for such lines. An
 engineer who has added nothing but a newline character becomes the last

--- a/docs/description/NoArrayTrailingComma.md
+++ b/docs/description/NoArrayTrailingComma.md
@@ -3,16 +3,21 @@ Rationale: JLS allows trailing commas in arrays and enumerations, but
 does not allow them in other locations. To unify the coding style, the
 use of trailing commas should be prohibited.
 
-    int[] foo = new int[] {
-      1,
-      2
-    };
-            
+``` 
+int[] foo = new int[] {
+  1,
+  2
+};
+        
+```
 
 The check demands that there should not be any comma after the last
 element of an array.
 
-    String[] foo = new String[] {
-      "FOO",
-      "BAR", //violation
-    }
+``` 
+String[] foo = new String[] {
+  "FOO",
+  "BAR", //violation
+}
+        
+```

--- a/docs/description/NoClone.md
+++ b/docs/description/NoClone.md
@@ -3,7 +3,7 @@ Checks that the clone method is not overridden from the Object class.
 This check is almost exactly the same as the `NoFinalizerCheck`.
 
 See
-[Object.clone()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Object.html#clone())
+[Object.clone()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Object.html#clone\(\))
 
 Rationale: The clone method relies on strange, hard to follow rules that
 are difficult to get right and do not work in all situations. In some
@@ -16,24 +16,24 @@ Java: Programming Language Guide First Edition by Joshua Bloch pages
 Below are some of the rules/reasons why the clone method should be
 avoided.
 
--   Classes supporting the clone method should implement the Cloneable
+  - Classes supporting the clone method should implement the Cloneable
     interface but the Cloneable interface does not include the clone
     method. As a result, it doesn't enforce the method override.
--   The Cloneable interface forces the Object's clone method to work
+  - The Cloneable interface forces the Object's clone method to work
     correctly. Without implementing it, the Object's clone method will
     throw a CloneNotSupportedException.
--   Non-final classes must return the object returned from a call to
+  - Non-final classes must return the object returned from a call to
     super.clone().
--   Final classes can use a constructor to create a clone which is
+  - Final classes can use a constructor to create a clone which is
     different from non-final classes.
--   If a super class implements the clone method incorrectly all
+  - If a super class implements the clone method incorrectly all
     subclasses calling super.clone() are doomed to failure.
--   If a class has references to mutable objects then those object
+  - If a class has references to mutable objects then those object
     references must be replaced with copies in the clone method after
     calling super.clone().
--   The clone method does not work correctly with final mutable object
+  - The clone method does not work correctly with final mutable object
     references because final references cannot be reassigned.
--   If a super class overrides the clone method then all subclasses must
+  - If a super class overrides the clone method then all subclasses must
     provide a correct clone implementation.
 
 Two alternatives to the clone method, in some cases, is a copy
@@ -49,25 +49,31 @@ alternative to the clone method. The example below highlights the
 limitation of a copy constructor (or static factory). Assume Square is a
 subclass for Shape.
 
-    Shape s1 = new Square();
-    System.out.println(s1 instanceof Square); //true
-            
+``` 
+Shape s1 = new Square();
+System.out.println(s1 instanceof Square); //true
+        
+```
 
 ...assume at this point the code knows nothing of s1 being a Square
 that's the beauty of polymorphism but the code wants to copy the Square
 which is declared as a Shape, its super type...
 
-    Shape s2 = new Shape(s1); //using the copy constructor
-    System.out.println(s2 instanceof Square); //false
-            
+``` 
+Shape s2 = new Shape(s1); //using the copy constructor
+System.out.println(s2 instanceof Square); //false
+        
+```
 
 The working solution (without knowing about all subclasses and doing
 many casts) is to do the following (assuming correct clone
 implementation).
 
-    Shape s2 = s1.clone();
-    System.out.println(s2 instanceof Square); //true
-            
+``` 
+Shape s2 = s1.clone();
+System.out.println(s2 instanceof Square); //true
+        
+```
 
 Just keep in mind if this type of polymorphic cloning is required then a
 properly implemented clone method may be the best choice.

--- a/docs/description/NoCodeInFile.md
+++ b/docs/description/NoCodeInFile.md
@@ -1,6 +1,6 @@
 Checks whether file contains code. Files which are considered to have no
 code:
 
--   File with no text
--   File with single line comment(s)
--   File with a multi line comment(s).
+  - File with no text
+  - File with single line comment(s)
+  - File with a multi line comment(s).

--- a/docs/description/NoEnumTrailingComma.md
+++ b/docs/description/NoEnumTrailingComma.md
@@ -3,16 +3,21 @@ Rationale: JLS allows trailing commas in arrays and enumerations, but
 does not allow them in other locations. To unify the coding style, the
 use of trailing commas should be prohibited.
 
-    enum Foo1 {
-      FOO,
-      BAR;
-    }
-            
+``` 
+enum Foo1 {
+  FOO,
+  BAR;
+}
+        
+```
 
 The check demands that there should not be any comma after last constant
 in enum definition.
 
-    enum Foo1 {
-      FOO,
-      BAR, //violation
-    }
+``` 
+enum Foo1 {
+  FOO,
+  BAR, //violation
+}
+        
+```

--- a/docs/description/NoFinalizer.md
+++ b/docs/description/NoFinalizer.md
@@ -1,7 +1,7 @@
 Checks that there is no method `finalize` with zero parameters.
 
 See
-[Object.finalize()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Object.html#finalize())
+[Object.finalize()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Object.html#finalize\(\))
 
 Rationale: Finalizers are unpredictable, often dangerous, and generally
 unnecessary. Their use can cause erratic behavior, poor performance, and

--- a/docs/description/NoWhitespaceAfter.md
+++ b/docs/description/NoWhitespaceAfter.md
@@ -1,18 +1,17 @@
 Checks that there is no whitespace after a token. More specifically, it
 checks that it is not followed by whitespace, or (if linebreaks are
 allowed) all characters on the line after are whitespace. To forbid
-linebreaks after a token, set property `allowLineBreaks` to
-`           false`.
+linebreaks after a token, set property `allowLineBreaks` to `  false `.
 
 The check processes
-[ARRAY_DECLARATOR](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR)
+[ARRAY\_DECLARATOR](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR)
 and
-[INDEX_OP](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INDEX_OP)
+[INDEX\_OP](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INDEX_OP)
 tokens specially from other tokens. Actually it is checked that there is
 no whitespace before this tokens, not after them. Space after the
 [ANNOTATIONS](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATIONS)
 before
-[ARRAY_DECLARATOR](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR)
+[ARRAY\_DECLARATOR](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR)
 and
-[INDEX_OP](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INDEX_OP)
+[INDEX\_OP](apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INDEX_OP)
 will be ignored.

--- a/docs/description/OrderedProperties.md
+++ b/docs/description/OrderedProperties.md
@@ -8,8 +8,9 @@ improved. E.g.:
 checkstyle/src/main/resources/com/puppycrawl/tools/checkstyle/messages.properties
 You may suppress warnings of this check for files that have an logical
 structure like build files or log4j configuration files. See
-SuppressionFilter.
-`               <suppress checks="OrderedProperties"                   files="log4j.properties|ResourceBundle/Bug.*.properties|logging.properties"/>           `
+SuppressionFilter. `  <suppress checks="OrderedProperties"
+files="log4j.properties|ResourceBundle/Bug.*.properties|logging.properties"/>
+ `
 
 Known limitation: The key should not contain a newline. The string
 compare will work, but not the line number reporting.

--- a/docs/description/RedundantImport.md
+++ b/docs/description/RedundantImport.md
@@ -1,9 +1,9 @@
 Checks for redundant import statements. An import statement is
 considered redundant if:
 
--   It is a duplicate of another import. This is, when a class is
+  - It is a duplicate of another import. This is, when a class is
     imported more than once.
--   The class non-statically imported is from the `java.lang` package,
+  - The class non-statically imported is from the `java.lang` package,
     e.g. importing `java.lang.String`.
--   The class non-statically imported is from the same package as the
+  - The class non-statically imported is from the same package as the
     current package.

--- a/docs/description/RedundantModifier.md
+++ b/docs/description/RedundantModifier.md
@@ -28,25 +28,27 @@ automatically public, static and final just as their annotation fields
 are automatically public and abstract.
 
 Enums by definition are static implicit subclasses of
-java.lang.Enum\<E>. So, the `static` modifier on the enums is redundant.
-In addition, if enum is inside of interface, `public` modifier is also
-redundant.
+java.lang.Enum\<E\>. So, the `static` modifier on the enums is
+redundant. In addition, if enum is inside of interface, `public`
+modifier is also redundant.
 
 Enums can also contain abstract methods and methods which can be
 overridden by the declared enumeration fields. See the following
 example:
 
-    public enum EnumClass {
-      FIELD_1,
-      FIELD_2 {
-        @Override
-        public final void method1() {} // violation expected
-      };
+``` 
+public enum EnumClass {
+  FIELD_1,
+  FIELD_2 {
+    @Override
+    public final void method1() {} // violation expected
+  };
 
-      public void method1() {}
-      public final void method2() {} // no violation expected
-    }
-            
+  public void method1() {}
+  public final void method2() {} // no violation expected
+}
+        
+```
 
 Since these methods can be overridden in these situations, the final
 methods are not marked as redundant even though they can't be extended
@@ -60,28 +62,33 @@ on the method of a final class is redundant.
 Public modifier for constructors in non-public non-protected classes is
 always obsolete:
 
-    public class PublicClass {
-      public PublicClass() {} // OK
-    }
+``` 
+public class PublicClass {
+  public PublicClass() {} // OK
+}
 
-    class PackagePrivateClass {
-      public PackagePrivateClass() {} // violation expected
-    }
-            
+class PackagePrivateClass {
+  public PackagePrivateClass() {} // violation expected
+}
+        
+```
 
 There is no violation in the following example, because removing public
 modifier from ProtectedInnerClass constructor will make this code not
 compiling:
 
-    package a;
-    public class ClassExample {
-      protected class ProtectedInnerClass {
-        public ProtectedInnerClass () {}
-      }
-    }
+``` 
+package a;
+public class ClassExample {
+  protected class ProtectedInnerClass {
+    public ProtectedInnerClass () {}
+  }
+}
 
-    package b;
-    import a.ClassExample;
-    public class ClassExtending extends ClassExample {
-      ProtectedInnerClass pc = new ProtectedInnerClass();
-    }
+package b;
+import a.ClassExample;
+public class ClassExtending extends ClassExample {
+  ProtectedInnerClass pc = new ProtectedInnerClass();
+}
+        
+```

--- a/docs/description/Regexp.md
+++ b/docs/description/Regexp.md
@@ -16,12 +16,12 @@ changes in the regular expressions used to achieve a particular end.
 
 In multiline mode...
 
--   `^` means the beginning of a line, as opposed to beginning of the
+  - `^` means the beginning of a line, as opposed to beginning of the
     input.
--   For beginning of the input use `\A`.
--   `$` means the end of a line, as opposed to the end of the input.
--   For end of input use `\Z`.
--   Each line in the file is terminated with a line feed character.
+  - For beginning of the input use `\A`.
+  - `$` means the end of a line, as opposed to the end of the input.
+  - For end of input use `\Z`.
+  - Each line in the file is terminated with a line feed character.
 
 **Note:** Not all regular expression engines are created equal. Some
 provide extra functions that others do not and some elements of the
@@ -32,5 +32,5 @@ expression to achieve a particular goal.
 
 **Note:** When entering a regular expression as a parameter in the XML
 config file you must also take into account the XML rules. e.g. if you
-want to match a \< symbol you need to enter &lt;. The regular expression
-should be entered on one line.
+want to match a \< symbol you need to enter \&lt;. The regular
+expression should be entered on one line.

--- a/docs/description/RegexpHeader.md
+++ b/docs/description/RegexpHeader.md
@@ -10,21 +10,23 @@ year information is not static.
 
 For example, consider the following header:
 
-    line  1: ^/{71}$
-    line  2: ^// checkstyle:$
-    line  3: ^// Checks Java source code for adherence to a set of rules\.$
-    line  4: ^// Copyright \(C\) \d\d\d\d  Oliver Burn$
-    line  5: ^// Last modification by \$Author.*\$$
-    line  6: ^/{71}$
-    line  7:
-    line  8: ^package
-    line  9:
-    line 10: ^import
-    line 11:
-    line 12: ^/\*\*
-    line 13: ^ \*([^/]|$)
-    line 14: ^ \*/
-            
+``` 
+line  1: ^/{71}$
+line  2: ^// checkstyle:$
+line  3: ^// Checks Java source code for adherence to a set of rules\.$
+line  4: ^// Copyright \(C\) \d\d\d\d  Oliver Burn$
+line  5: ^// Last modification by \$Author.*\$$
+line  6: ^/{71}$
+line  7:
+line  8: ^package
+line  9:
+line 10: ^import
+line 11:
+line 12: ^/\*\*
+line 13: ^ \*([^/]|$)
+line 14: ^ \*/
+        
+```
 
 Lines 1 and 6 demonstrate a more compact notation for 71 '/' characters.
 Line 4 enforces that the copyright notice includes a four digit year.
@@ -41,16 +43,18 @@ with a single header definition. For example, consider the following
 header specification (note that this is not the full Apache license
 header):
 
-    line 1: ^#!
-    line 2: ^<\?xml.*>$
-    line 3: ^\W*$
-    line 4: ^\W*Copyright 2006 The Apache Software Foundation or its licensors, as applicable\.$
-    line 5: ^\W*Licensed under the Apache License, Version 2\.0 \(the "License"\);$
-    line 6: ^\W*$
-            
+``` 
+line 1: ^#!
+line 2: ^<\?xml.*>$
+line 3: ^\W*$
+line 4: ^\W*Copyright 2006 The Apache Software Foundation or its licensors, as applicable\.$
+line 5: ^\W*Licensed under the Apache License, Version 2\.0 \(the "License"\);$
+line 6: ^\W*$
+        
+```
 
 Lines 1 and 2 leave room for technical header lines, e.g. the
-"#!/bin/sh" line in Unix shell scripts, or the XML file header of XML
+"\#\!/bin/sh" line in Unix shell scripts, or the XML file header of XML
 files. Set the multiline property to "1, 2" so these lines can be
 ignored for file types where they do no apply. Lines 3 through 6 define
 the actual header content. Note how lines 2, 4 and 5 use escapes for

--- a/docs/description/RegexpSingleline.md
+++ b/docs/description/RegexpSingleline.md
@@ -1,5 +1,5 @@
 Checks that a specified pattern matches a single line in any file type.
 
 Rationale: This check can be used to prototype checks and to find common
-bad practice such as calling `ex.printStacktrace()`,
-`           System.out.println()`, `System.exit()`, etc.
+bad practice such as calling `ex.printStacktrace()`, ` 
+System.out.println() `, `System.exit()`, etc.

--- a/docs/description/RightCurly.md
+++ b/docs/description/RightCurly.md
@@ -4,6 +4,6 @@ for-loops, method definitions, class definitions, constructor
 definitions, instance, static initialization blocks, annotation
 definitions and enum definitions. For right curly brace of expression
 blocks of arrays, lambdas and class instances please follow issue
-[#5945](https://github.com/checkstyle/checkstyle/issues/5945). For right
-curly brace of enum constant please follow issue
-[#7519](https://github.com/checkstyle/checkstyle/issues/7519).
+[\#5945](https://github.com/checkstyle/checkstyle/issues/5945). For
+right curly brace of enum constant please follow issue
+[\#7519](https://github.com/checkstyle/checkstyle/issues/7519).

--- a/docs/description/SimplifyBooleanExpression.md
+++ b/docs/description/SimplifyBooleanExpression.md
@@ -1,5 +1,5 @@
 Checks for over-complicated boolean expressions. Currently finds code
-like ` if (b == true)`, `b || true`, `!false`, etc.
+like `  if (b == true) `, `b || true`, `!false`, etc.
 
 Rationale: Complex boolean logic makes code hard to understand and
 maintain.

--- a/docs/description/SimplifyBooleanReturn.md
+++ b/docs/description/SimplifyBooleanReturn.md
@@ -1,16 +1,20 @@
 Checks for over-complicated boolean return statements. For example the
 following code
 
-    if (valid())
-      return false;
-    else
-      return true;
-            
+``` 
+if (valid())
+  return false;
+else
+  return true;
+        
+```
 
 could be written as
 
-    return !valid();
-            
+``` 
+return !valid();
+        
+```
 
 The idea for this Check has been shamelessly stolen from the equivalent
 [PMD](https://pmd.github.io/) rule.

--- a/docs/description/SingleSpaceSeparator.md
+++ b/docs/description/SingleSpaceSeparator.md
@@ -6,15 +6,20 @@ inspect whitespaces before and after comments, set the property
 
 Setting `validateComments` to false will ignore cases like:
 
-    int i;  // Multiple whitespaces before comment tokens will be ignored.
-    private void foo(int  /* whitespaces before and after block-comments will be
-    ignored */  i) {
-            
+``` 
+int i;  // Multiple whitespaces before comment tokens will be ignored.
+private void foo(int  /* whitespaces before and after block-comments will be
+ignored */  i) {
+        
+```
 
 Sometimes, users like to space similar items on different lines to the
 same column position for easier reading. This feature isn't supported by
 this check, so both braces in the following case will be reported as
 violations.
 
-    public long toNanos(long d)  { return d;             } // 2 violations
-    public long toMicros(long d) { return d / (C1 / C0); }
+``` 
+public long toNanos(long d)  { return d;             } // 2 violations
+public long toMicros(long d) { return d / (C1 / C0); }
+        
+```

--- a/docs/description/StringLiteralEquality.md
+++ b/docs/description/StringLiteralEquality.md
@@ -5,9 +5,14 @@ article](https://stackoverflow.com/questions/513832/how-do-i-compare-strings-in-
 
 Rationale: Novice Java programmers often use code like:
 
-    if (x == "something")
-            
+``` 
+if (x == "something")
+        
+```
 
 when they mean
 
-    if ("something".equals(x))
+``` 
+if ("something".equals(x))
+        
+```

--- a/docs/description/SuppressWarnings.md
+++ b/docs/description/SuppressWarnings.md
@@ -5,15 +5,14 @@ configured warning(s) cannot be suppressed on.
 Limitations: This check does not consider conditionals inside the
 @SuppressWarnings annotation.
 
-For example:
-`@SuppressWarnings((false) ? (true) ? "unchecked" : "foo" : "unused")`.
-According to the above example, the "unused" warning is being suppressed
-not the "unchecked" or "foo" warnings. All of these warnings will be
-considered and matched against regardless of what the conditional
-evaluates to. The check also does not support code like
-`@SuppressWarnings("un" + "used")`,
-`@SuppressWarnings((String) "unused")` or
-`@SuppressWarnings({('u' + (char)'n') + (""+("used" + (String)"")),})`.
+For example: `@SuppressWarnings((false) ? (true) ? "unchecked" : "foo" :
+"unused")`. According to the above example, the "unused" warning is
+being suppressed not the "unchecked" or "foo" warnings. All of these
+warnings will be considered and matched against regardless of what the
+conditional evaluates to. The check also does not support code like
+`@SuppressWarnings("un" + "used")`, `@SuppressWarnings((String)
+"unused")` or `@SuppressWarnings({('u' + (char)'n') + (""+("used" +
+(String)"")),})`.
 
 By default, any warning specified will be disallowed on all legal
 TokenTypes unless otherwise specified via the tokens property.

--- a/docs/description/TrailingComment.md
+++ b/docs/description/TrailingComment.md
@@ -1,38 +1,40 @@
 The check to ensure that lines with code do not end with comment. For
 the case of `//` comments that means that the only thing that should
 precede it is whitespace. It doesn't check comments if they do not end a
-line; for example, it accepts the following:
-`Thread.sleep( 10 /*some comment here*/ );` Format property is intended
-to deal with the `} // while` example.
+line; for example, it accepts the following: `Thread.sleep( 10 /*some
+comment here*/ );` Format property is intended to deal with the `} //
+while` example.
 
 Rationale: Steve McConnell in Code Complete suggests that endline
 comments are a bad practice. An end line comment would be one that is on
 the same line as actual code. For example:
 
-    a = b + c;      // Some insightful comment
-    d = e / f;        // Another comment for this line
-            
+``` 
+a = b + c;      // Some insightful comment
+d = e / f;        // Another comment for this line
+        
+```
 
 Quoting Code Complete for the justification:
 
--   "The comments have to be aligned so that they do not interfere with
+  - "The comments have to be aligned so that they do not interfere with
     the visual structure of the code. If you don't align them neatly,
     they'll make your listing look like it's been through a washing
     machine."
--   "Endline comments tend to be hard to format...It takes time to align
+  - "Endline comments tend to be hard to format...It takes time to align
     them. Such time is not spent learning more about the code; it's
     dedicated solely to the tedious task of pressing the spacebar or tab
     key."
--   "Endline comments are also hard to maintain. If the code on any line
+  - "Endline comments are also hard to maintain. If the code on any line
     containing an endline comment grows, it bumps the comment farther
     out, and all the other endline comments will have to bumped out to
     match. Styles that are hard to maintain aren't maintained...."
--   "Endline comments also tend to be cryptic. The right side of the
+  - "Endline comments also tend to be cryptic. The right side of the
     line doesn't offer much room and the desire to keep the comment on
     one line means the comment must be short. Work then goes into making
     the line as short as possible instead of as clear as possible. The
     comment usually ends up as cryptic as possible...."
--   "A systemic problem with endline comments is that it's hard to write
+  - "A systemic problem with endline comments is that it's hard to write
     a meaningful comment for one line of code. Most endline comments
     just repeat the line of code, which hurts more than it helps."
 

--- a/docs/description/Translation.md
+++ b/docs/description/Translation.md
@@ -6,20 +6,25 @@ which must exist in project, if `requiredTranslations` option is used.
 
 Consider the following properties file in the same directory:
 
-    #messages.properties
-    hello=Hello
-    cancel=Cancel
+``` 
+#messages.properties
+hello=Hello
+cancel=Cancel
 
-    #messages_de.properties
-    hell=Hallo
-    ok=OK
-            
+#messages_de.properties
+hell=Hallo
+ok=OK
+        
+```
 
 The Translation check will find the typo in the German `hello` key, the
 missing `ok` key in the default resource file and the missing `cancel`
 key in the German resource file:
 
-    messages_de.properties: Key 'hello' missing.
-    messages_de.properties: Key 'cancel' missing.
-    messages.properties: Key 'hell' missing.
-    messages.properties: Key 'ok' missing.
+``` 
+messages_de.properties: Key 'hello' missing.
+messages_de.properties: Key 'cancel' missing.
+messages.properties: Key 'hell' missing.
+messages.properties: Key 'ok' missing.
+        
+```

--- a/docs/description/UnnecessaryParentheses.md
+++ b/docs/description/UnnecessaryParentheses.md
@@ -1,12 +1,15 @@
 Checks if unnecessary parentheses are used in a statement or expression.
 The check will flag the following with warnings:
 
-    return (x);          // parens around identifier
-    return (x + 1);      // parens around return value
-    int x = (y / 2 + 1); // parens around assignment rhs
-    for (int i = (0); i < 10; i++) {  // parens around literal
-    t -= (z + 1);                     // parens around assignment rhs
-    boolean a = (x > 7 && y > 5)      // parens around expression
-                || z < 9;
-    boolean b = (~a) > -27            // parens around ~a
-                && (a-- < 30);        // parens around expression
+``` 
+return (x);          // parens around identifier
+return (x + 1);      // parens around return value
+int x = (y / 2 + 1); // parens around assignment rhs
+for (int i = (0); i < 10; i++) {  // parens around literal
+t -= (z + 1);                     // parens around assignment rhs
+boolean a = (x > 7 && y > 5)      // parens around expression
+            || z < 9;
+boolean b = (~a) > -27            // parens around ~a
+            && (a-- < 30);        // parens around expression
+        
+```

--- a/docs/description/UnusedImports.md
+++ b/docs/description/UnusedImports.md
@@ -2,16 +2,15 @@ Checks for unused import statements. Checkstyle uses a simple but very
 reliable algorithm to report on unused import statements. An import
 statement is considered unused if:
 
--   It is not referenced in the file. The algorithm does not support
-    wild-card imports like `import             java.io.*;`. Most IDE's
-    provide very sophisticated checks for imports that handle wild-card
-    imports.
--   It is a duplicate of another import. This is when a class is
+  - It is not referenced in the file. The algorithm does not support
+    wild-card imports like `import java.io.*;`. Most IDE's provide very
+    sophisticated checks for imports that handle wild-card imports.
+  - It is a duplicate of another import. This is when a class is
     imported more than once.
--   The class imported is from the `java.lang` package. For example
+  - The class imported is from the `java.lang` package. For example
     importing `java.lang.String`.
--   The class imported is from the same package.
--   **Optionally:** it is referenced in Javadoc comments. This check is
+  - The class imported is from the same package.
+  - **Optionally:** it is referenced in Javadoc comments. This check is
     on by default, but it is considered bad practice to introduce a
     compile time dependency for documentation purposes only. As an
     example, the import `java.util.List` would be considered referenced
@@ -25,8 +24,11 @@ type has the same name as a declaration, such as a member variable.
 For example, in the following case the import `java.awt.Component` will
 not be flagged as unused:
 
-    import java.awt.Component;
-    class FooBar {
-      private Object Component; // a bad practice in my opinion
-      ...
-    }
+``` 
+import java.awt.Component;
+class FooBar {
+  private Object Component; // a bad practice in my opinion
+  ...
+}
+        
+```

--- a/docs/description/UpperEll.md
+++ b/docs/description/UpperEll.md
@@ -1,6 +1,6 @@
 Checks that long constants are defined with an upper ell. That is `'L'`
 and not `'l'`. This is in accordance with the Java Language
-Specification, [Section
-3.10.1](https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-3.10.1).
+Specification,
+[Section 3.10.1](https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-3.10.1).
 
 Rationale: The lower-case ell `'l'` looks a lot like `1`.

--- a/docs/description/VisibilityModifier.md
+++ b/docs/description/VisibilityModifier.md
@@ -28,8 +28,8 @@ declared as public if defined in final class.
 
 Field is known to be immutable if:
 
--   It's declared as final
--   Has either a primitive type or instance of class user defined to be
+  - It's declared as final
+  - Has either a primitive type or instance of class user defined to be
     immutable (such as String, ImmutableCollection from Guava and etc)
 
 Classes known to be immutable are listed in

--- a/docs/description/WhitespaceAround.md
+++ b/docs/description/WhitespaceAround.md
@@ -2,32 +2,36 @@ Checks that a token is surrounded by whitespace. Empty constructor,
 method, class, enum, interface, loop bodies (blocks), lambdas of the
 form
 
-    public MyClass() {}      // empty constructor
-    public void func() {}    // empty method
-    public interface Foo {} // empty interface
-    public class Foo {} // empty class
-    public enum Foo {} // empty enum
-    MyClass c = new MyClass() {}; // empty anonymous class
-    while (i = 1) {} // empty while loop
-    for (int i = 1; i > 1; i++) {} // empty for loop
-    do {} while (i = 1); // empty do-while loop
-    Runnable noop = () -> {}; // empty lambda
-    public @interface Beta {} // empty annotation type
-            
+``` 
+public MyClass() {}      // empty constructor
+public void func() {}    // empty method
+public interface Foo {} // empty interface
+public class Foo {} // empty class
+public enum Foo {} // empty enum
+MyClass c = new MyClass() {}; // empty anonymous class
+while (i = 1) {} // empty while loop
+for (int i = 1; i > 1; i++) {} // empty for loop
+do {} while (i = 1); // empty do-while loop
+Runnable noop = () -> {}; // empty lambda
+public @interface Beta {} // empty annotation type
+        
+```
 
-may optionally be exempted from the policy using the
-`           allowEmptyMethods`, `allowEmptyConstructors`,
-`allowEmptyTypes`, `allowEmptyLoops`, `allowEmptyLambdas` and
-`allowEmptyCatches` properties.
+may optionally be exempted from the policy using the ` 
+allowEmptyMethods `, `allowEmptyConstructors`, `allowEmptyTypes`,
+`allowEmptyLoops`, `allowEmptyLambdas` and `allowEmptyCatches`
+properties.
 
 This check does not flag as violation double brace initialization like:
 
 <div class="wrapper">
 
-    new Properties() {{
-        setProperty("key", "value");
-    }};
-              
+``` 
+new Properties() {{
+    setProperty("key", "value");
+}};
+          
+```
 
 </div>
 
@@ -37,10 +41,12 @@ whitespace and catch block is empty, for example:
 
 <div class="wrapper">
 
-    try {
-        k = 5 / i;
-    } catch (ArithmeticException ex) {}
-              
+``` 
+try {
+    k = 5 / i;
+} catch (ArithmeticException ex) {}
+          
+```
 
 </div>
 

--- a/docs/multiple-tests/default-rules-regex/patterns.xml
+++ b/docs/multiple-tests/default-rules-regex/patterns.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<module name="root">
+    <module name="PackageName" />
+</module>

--- a/docs/multiple-tests/default-rules-regex/results.xml
+++ b/docs/multiple-tests/default-rules-regex/results.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="4.3">
+    <file name="PackageName_not_ok.java">
+        <error source="PackageName"
+               line="1"
+               message="Name 'COM' must match pattern '^[a-z]+(\.[a-zA-Z_][a-zA-Z0-9_]*)*$'."
+               severity="info"
+        />
+    </file>
+</checkstyle>

--- a/docs/multiple-tests/default-rules-regex/src/PackageName_not_ok.java
+++ b/docs/multiple-tests/default-rules-regex/src/PackageName_not_ok.java
@@ -1,0 +1,7 @@
+package COM;
+
+public class Something {
+    private void foo() {
+        System.out.print("bar");
+    }
+}

--- a/docs/multiple-tests/default-rules-regex/src/PackageName_ok.java
+++ b/docs/multiple-tests/default-rules-regex/src/PackageName_ok.java
@@ -1,0 +1,7 @@
+package com.A.checkstyle.checks;
+
+public class Something {
+    private void foo() {
+        System.out.print("bar");
+    }
+}

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -356,7 +356,7 @@
       "default" : "^$"
     }, {
       "name" : "standardPackageRegExp",
-      "default" : "\"^(java|javax)\\.\""
+      "default" : "^(java|javax)\\."
     }, {
       "name" : "thirdPartyPackageRegExp",
       "default" : ".*"
@@ -1091,7 +1091,7 @@
       "default" : true
     }, {
       "name" : "endOfSentenceFormat",
-      "default" : "([.?!][ \t\n\r\f<])|([.?!]$)"
+      "default" : "([.?!][ \\t\\n\\r\\f<])|([.?!]$)"
     }, {
       "name" : "excludeScope",
       "default" : null
@@ -1514,7 +1514,7 @@
       "default" : "ANNOTATION"
     }, {
       "name" : "ignoreStringsRegexp",
-      "default" : "^"
+      "default" : "^\"\"$"
     } ],
     "languages" : [ ],
     "enabled" : false
@@ -1778,7 +1778,7 @@
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "format",
-      "default" : "\"^[a-z]+(\\.[a-zA-Z_][a-zA-Z0-9_]*)*$\""
+      "default" : "^[a-z]+(\\.[a-zA-Z_][a-zA-Z0-9_]*)*$"
     } ],
     "languages" : [ ],
     "enabled" : false
@@ -2214,7 +2214,7 @@
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "format",
-      "default" : "\"^\\s*+$\""
+      "default" : "^\\s*+$"
     }, {
       "name" : "tokens",
       "default" : "CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF, ENUM_CONSTANT_DEF, PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, CTOR_DEF, COMPACT_CTOR_DEF, RECORD_DEF"
@@ -2260,7 +2260,7 @@
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "format",
-      "default" : "\"^[\\s});]*$\""
+      "default" : "^[\\s});]*$"
     }, {
       "name" : "legalComment",
       "default" : null

--- a/src/main/scala/codacy/checkstyle/DocGenerator.scala
+++ b/src/main/scala/codacy/checkstyle/DocGenerator.scala
@@ -79,7 +79,7 @@ object DocGenerator {
                     // Remove spaces and breaklines in default values
                     val defVal = default.text.replaceAll("""\n\s+""", "").trim.stripSuffix(".")
                     // Remove quotes around regular expressions
-                    if (tpe.text.trim == "Regular Expression" && defVal != "null") {
+                    if (tpe.text.trim == "Pattern" && defVal != "null") {
                       // Leaves only what's inside outer quotes.
                       val f: Char => Boolean = _ != '"'
                       defVal.dropWhile(f).reverse.dropWhile(f).reverse.stripPrefix("\"").stripSuffix("\"")


### PR DESCRIPTION
This fixes https://github.com/codacy/codacy-checkstyle/issues/85

When generating docs, we need to check for "Pattern" instead of the old "Regular Expression" on the type of the Properties