### PR TITLE
fix: Update Dockerfile for ARM CPUs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM eclipse-temurin:11-jre-alpine
-RUN apk add bash
+FROM eclipse-temurin:11-jre
+RUN apt-get install bash
 COPY docs /docs
 COPY target/universal/stage/ /opt/docker/
-RUN adduser -u 2004 -D docker && chmod +x /opt/docker/bin/codacy-checkstyle
+RUN adduser -u 2004 docker && chmod +x /opt/docker/bin/codacy-checkstyle
 USER docker
 WORKDIR /src
 ENTRYPOINT ["/opt/docker/bin/codacy-checkstyle"]


### PR DESCRIPTION
This PR changes the base docker image from `eclipse-temurin:11-jre-alpine` to `eclipse-temurin:11-jre`, as the previous image has no support for armv64 CPU's. This change should allow M1 MacBook owners to run the tool locally.

More testing still needs to be done, especially with an `amd64` machine.